### PR TITLE
Add more `ChainRules` `rrule`s for ITensor operations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,9 +7,10 @@ version = "0.0.1"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
+ChainRulesCore = "0.10"
 ITensors = "0.2"
 Reexport = "1"
-ChainRulesCore = "0.10"
 julia = "1.3"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,7 @@ DocMeta.setdocmeta!(
 makedocs(;
   modules=[ITensorNetworkAD],
   authors="Matthew Fishman <mfishman@flatironinstitute.org>, Linjian Ma <lma16@illinois.edu>",
-  repo="https://github.com/itensor/ITensorNetworkAD.jl/blob/{commit}{path}#{line}",
+  repo="https://github.com/ITensor/ITensorNetworkAD.jl/blob/{commit}{path}#{line}",
   sitename="ITensorNetworkAD.jl",
   format=Documenter.HTML(;
     prettyurls=get(ENV, "CI", "false") == "true",

--- a/src/ITensorChainRules/ITensorChainRules.jl
+++ b/src/ITensorChainRules/ITensorChainRules.jl
@@ -170,6 +170,15 @@ function ChainRulesCore.rrule(::typeof(ITensor), x::Number)
   return y, ITensor_pullback
 end
 
+function ChainRulesCore.rrule(::typeof(dag), x::ITensor)
+  y = dag(x)
+  function dag_pullback(ȳ)
+    x̄ = dag(ȳ)
+    return (NoTangent(), x̄)
+  end
+  return y, dag_pullback
+end
+
 @non_differentiable Index(::Any...)
 @non_differentiable delta(::Any...)
 @non_differentiable dag(::Index)

--- a/src/ITensorChainRules/ITensorChainRules.jl
+++ b/src/ITensorChainRules/ITensorChainRules.jl
@@ -20,6 +20,18 @@ function ChainRulesCore.rrule(::typeof(getindex), x::ITensor, I...)
   return y, getindex_pullback
 end
 
+# Specialized version in order to avoid call to `setindex!`
+# within the pullback, should be better for taking higher order
+# derivatives in Zygote.
+function ChainRulesCore.rrule(::typeof(getindex), x::ITensor)
+  y = x[]
+  function getindex_pullback(ȳ)
+    x̄ = ITensor(ȳ)
+    return (NoTangent(), x̄)
+  end
+  return y, getindex_pullback
+end
+
 function setinds_pullback(ȳ, x, a...)
   x̄ = ITensors.setinds(ȳ, inds(x))
   ā = broadcast(_ -> NoTangent(), a)

--- a/src/ITensorChainRules/ITensorChainRules.jl
+++ b/src/ITensorChainRules/ITensorChainRules.jl
@@ -36,7 +36,11 @@ function setinds_pullback(ȳ, x, a...)
   return (NoTangent(), x̄, ā...)
 end
 
-inv_op(f::Function, args...) = error("The inverse of the operation (`inv_op`) for function `$f` and arguments $args not defined.")
+function inv_op(f::Function, args...)
+  return error(
+    "The inverse of the operation (`inv_op`) for function `$f` and arguments $args not defined.",
+  )
+end
 
 function inv_op(::typeof(prime), x::ITensor, n::Integer=1)
   return prime(x, -n)

--- a/src/ITensorChainRules/ITensorChainRules.jl
+++ b/src/ITensorChainRules/ITensorChainRules.jl
@@ -3,10 +3,16 @@
 using ChainRulesCore
 using ITensors
 
+# Needed for defining the rule for `adjoint(A::ITensor)`
+# which currently doesn't work by overloading `ChainRulesCore.rrule`
+using ZygoteRules: @adjoint
+
 function ChainRulesCore.rrule(::typeof(getindex), x::ITensor, I...)
   y = getindex(x, I...)
   function getindex_pullback(ȳ)
-    x̄ = ITensor(inds(x))
+    # TODO: add definition `ITensor(::Tuple{}) = ITensor()`
+    # to ITensors.jl so no splatting is needed here.
+    x̄ = ITensor(inds(x)...)
     x̄[I...] = ȳ
     Ī = broadcast(_ -> NoTangent(), I)
     return (NoTangent(), x̄, Ī...)
@@ -14,14 +20,147 @@ function ChainRulesCore.rrule(::typeof(getindex), x::ITensor, I...)
   return y, getindex_pullback
 end
 
-function ChainRulesCore.rrule(::typeof(*), x1::ITensor, x2::ITensor)
+function setinds_pullback(ȳ, x, a...)
+  x̄ = ITensors.setinds(ȳ, inds(x))
+  ā = broadcast(_ -> NoTangent(), a)
+  return (NoTangent(), x̄, ā...)
+end
+
+for fname in (
+  :prime,
+  :setprime,
+  :noprime,
+  :replaceprime,
+  :swapprime,
+  :addtags,
+  :removetags,
+  :replacetags,
+  :settags,
+  :swaptags,
+  :replaceind,
+  :replaceinds,
+  :swapind,
+  :swapinds,
+)
+  @eval begin
+    function ChainRulesCore.rrule(::typeof($fname), x::ITensor, a...)
+      y = $fname(x, a...)
+      function f_pullback(ȳ)
+        return setinds_pullback(ȳ, x, a...)
+      end
+      return y, f_pullback
+    end
+  end
+end
+
+# TODO: This is not being called by Zygote for some reason,
+# using a Zygote overload directly instead. Figure out
+# why, maybe raise an issue.
+#function ChainRulesCore.rrule(::typeof(adjoint), x::ITensor)
+#  y = prime(x)
+#  function adjoint_pullback(ȳ)
+#    return setinds_pullback(ȳ, x)
+#  end
+#  return y, adjoint_pullback
+#end
+
+@adjoint function Base.adjoint(x::ITensor)
+  y = prime(x)
+  function setinds_pullback(ȳ)
+    x̄ = ITensors.setinds(ȳ, inds(x))
+    return (x̄,)
+  end
+  return y, setinds_pullback
+end
+
+function _contract_pullback(ȳ, x1, x2)
+  x̄1 = ȳ * x2
+  x̄2 = x1 * ȳ
+  return (NoTangent(), x̄1, x̄2)
+end
+
+function _rrule(::typeof(*), x1, x2)
   y = x1 * x2
   function contract_pullback(ȳ)
-    x̄1 = ȳ * x2
-    x̄2 = x1 * ȳ
-    return (NoTangent(), x̄1, x̄2)
+    return _contract_pullback(ȳ, x1, x2)
   end
   return y, contract_pullback
 end
+
+# Special case for contracting a pair of ITensors
+function ChainRulesCore.rrule(::typeof(*), x1::ITensor, x2::ITensor)
+  return _rrule(*, x1, x2)
+end
+
+function ChainRulesCore.rrule(::typeof(*), x1::Number, x2::ITensor)
+  return _rrule(*, x1, x2)
+end
+
+function ChainRulesCore.rrule(::typeof(*), x1::ITensor, x2::Number)
+  return _rrule(*, x1, x2)
+end
+
+function ChainRulesCore.rrule(::typeof(*), x1::ITensor, x2::ITensor, xs::ITensor...)
+  y = *(x1, x2, xs...)
+  function contract_pullback(ȳ)
+    # TODO: use some contraction sequence optimization here
+    tn = [x1, x2, xs...]
+    N = length(tn)
+    env_contracted = Vector{ITensor}(undef, N)
+    for n in 1:length(tn)
+      tn_left = tn[1:(n - 1)]
+      # TODO: define contract([]) = ITensor(1.0)
+      env_left = isempty(tn_left) ? ITensor(1.0) : contract(tn_left)
+      tn_right = tn[reverse((n + 1):end)]
+      env_right = isempty(tn_right) ? ITensor(1.0) : contract(tn_right)
+      env_contracted[n] = env_left * ȳ * env_right
+    end
+    return (NoTangent(), env_contracted...)
+  end
+  return y, contract_pullback
+end
+
+function ChainRulesCore.rrule(::typeof(+), x1::ITensor, x2::ITensor)
+  y = x1 + x2
+  function add_pullback(ȳ)
+    return (NoTangent(), ȳ, ȳ)
+  end
+  return y, add_pullback
+end
+
+function ChainRulesCore.rrule(::typeof(itensor), x::Array, a...)
+  y = itensor(x, a...)
+  function itensor_pullback(ȳ)
+    x̄ = array(ȳ)
+    ā = broadcast(_ -> NoTangent(), a)
+    return (NoTangent(), x̄, ā...)
+  end
+  return y, itensor_pullback
+end
+
+function ChainRulesCore.rrule(::typeof(ITensor), x::Array, a...)
+  y = ITensor(x, a...)
+  function ITensor_pullback(ȳ)
+    # TODO: define `Array(::ITensor)` directly
+    x̄ = Array(ȳ, inds(ȳ)...)
+    ā = broadcast(_ -> NoTangent(), a)
+    return (NoTangent(), x̄, ā...)
+  end
+  return y, ITensor_pullback
+end
+
+function ChainRulesCore.rrule(::typeof(ITensor), x::Number)
+  y = ITensor(x)
+  function ITensor_pullback(ȳ)
+    x̄ = ȳ[]
+    return (NoTangent(), x̄)
+  end
+  return y, ITensor_pullback
+end
+
+@non_differentiable Index(::Any...)
+@non_differentiable delta(::Any...)
+@non_differentiable dag(::Index)
+@non_differentiable inds(::Any...)
 
 end

--- a/src/ITensorChainRules/zygoterules.jl
+++ b/src/ITensorChainRules/zygoterules.jl
@@ -1,0 +1,13 @@
+
+# Needed for defining the rule for `adjoint(A::ITensor)`
+# which currently doesn't work by overloading `ChainRulesCore.rrule`
+using ZygoteRules: @adjoint
+
+@adjoint function Base.adjoint(x::ITensor)
+  y = prime(x)
+  function setinds_pullback(ȳ)
+    x̄ = ITensors.setinds(ȳ, inds(x))
+    return (x̄,)
+  end
+  return y, setinds_pullback
+end

--- a/src/ITensorChainRules/zygoterules.jl
+++ b/src/ITensorChainRules/zygoterules.jl
@@ -5,9 +5,9 @@ using ZygoteRules: @adjoint
 
 @adjoint function Base.adjoint(x::ITensor)
   y = prime(x)
-  function setinds_pullback(ȳ)
-    x̄ = ITensors.setinds(ȳ, inds(x))
+  function adjoint_pullback(ȳ)
+    x̄ = inv_op(prime, ȳ)
     return (x̄,)
   end
-  return y, setinds_pullback
+  return y, adjoint_pullback
 end

--- a/test/ITensorChainRules/runtests.jl
+++ b/test/ITensorChainRules/runtests.jl
@@ -194,12 +194,11 @@ end
   f = x -> ITensor(x)
   args = (2.12,)
   test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
-  f =
-    x -> (
-      j = Index(2); T = itensor([x^2 sin(x); x^2 exp(-2x)], j', dag(j)); real(
-        (dag(T) * T)[]
-      )
-    )
+  f = function (x)
+    j = Index(2)
+    T = itensor([x^2 sin(x); x^2 exp(-2x)], j', dag(j))
+    return real((dag(T) * T)[])
+  end
   args = (2.8,)
   test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   args = (2.8 + 3.1im,)

--- a/test/ITensorChainRules/runtests.jl
+++ b/test/ITensorChainRules/runtests.jl
@@ -1,6 +1,8 @@
+using ChainRulesCore
 using ChainRulesTestUtils
 using FiniteDifferences
 using ITensors
+using ITensors.NDTensors
 using ITensorNetworkAD
 using Random
 using Test
@@ -8,7 +10,19 @@ using Zygote
 
 using Zygote: ZygoteRuleConfig
 
+#
+# ITensor extensions
+#
+
+# TODO: this is to fix an error within `ChainRulesTestUtils._test_add!!_behaviour`
+# that gets called in `test_rrule`. Is this needed/a good definition?
+Base.:+(x::Number, y::ITensor) = ITensor(x) + y
+Base.:+(x::ITensor, y::Number) = x + ITensor(y)
+
+#
 # For ITensor compatibility with FiniteDifferences
+#
+
 function FiniteDifferences.to_vec(A::ITensor)
   # TODO: generalize to sparse tensors
   return vec(array(A)), x -> itensor(x, inds(A))
@@ -18,27 +32,153 @@ function FiniteDifferences.rand_tangent(rng::AbstractRNG, A::ITensor)
   return randomITensor(eltype(A), inds(A))
 end
 
+function FiniteDifferences.rand_tangent(rng::AbstractRNG, A::ITensor)
+  # TODO: generalize to sparse tensors
+  return randomITensor(eltype(A), inds(A))
+end
+
+function FiniteDifferences.rand_tangent(rng::AbstractRNG, A::Tensor)
+  # TODO: generalize to sparse tensors
+  return randomTensor(eltype(A), inds(A))
+end
+
+function FiniteDifferences.rand_tangent(rng::AbstractRNG, x::Index)
+  return NoTangent()
+end
+
+#
 # For ITensor compatibility with ChainRulesTestUtils
+#
+
 function ChainRulesTestUtils.test_approx(
   actual::ITensor, expected::ITensor, msg=""; kwargs...
 )
   ChainRulesTestUtils.@test_msg msg isapprox(actual, expected; kwargs...)
 end
 
+function ChainRulesTestUtils.test_approx(
+  actual::ITensor, expected::Number, msg=""; kwargs...
+)
+  ChainRulesTestUtils.@test_msg msg isapprox(actual[], expected; kwargs...)
+end
+
+function ChainRulesTestUtils.test_approx(
+  actual::Number, expected::ITensor, msg=""; kwargs...
+)
+  ChainRulesTestUtils.@test_msg msg isapprox(actual, expected[]; kwargs...)
+end
+
 @testset "ITensorChainRules.jl" begin
   i = Index(2)
-  A = randomITensor(i', i)
+  A = randomITensor(i', dag(i))
+  B = randomITensor(i', dag(i))
 
   test_rrule(getindex, A, 1, 1; check_inferred=false)
   test_rrule(getindex, A, 1, 2; check_inferred=false)
   test_rrule(*, A', A; check_inferred=false)
+  test_rrule(*, 3.2, A; check_inferred=false)
+  test_rrule(*, A, 4.3; check_inferred=false)
+  test_rrule(+, A, B; check_inferred=false)
+  test_rrule(prime, A; check_inferred=false)
+  test_rrule(prime, A, 2; check_inferred=false)
+  test_rrule(addtags, A, "i"; check_inferred=false)
+  test_rrule(settags, A, "x,y"; check_inferred=false)
+  # XXX: broken with some ambiguity error in ChainRulesTestUtils
+  #test_rrule(delta, (i', i); check_inferred=false)
+  test_rrule(itensor, randn(2, 2), i', i; check_inferred=false)
+  test_rrule(ITensor, randn(2, 2), i', i; check_inferred=false)
+  test_rrule(ITensor, 2.3; check_inferred=false)
 
-  test_rrule(
-    ZygoteRuleConfig(),
-    (x, y) -> (x * y)[1, 1],
-    A',
-    A;
-    rrule_f=rrule_via_ad,
-    check_inferred=false,
-  )
+  f = adjoint
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = (x, y) -> (x * y)[1, 1]
+  args = (A', A)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> prime(x, 2)[1, 1]
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> x'[1, 1]
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> addtags(x, "x")[1, 1]
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> (x' * x)[1, 1]
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> (prime(x) * x)[1, 1]
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> ((x'' * x') * x)[1, 1]
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> (x'' * (x' * x))[1, 1]
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = (x, y, z) -> (x * y * z)[1, 1]
+  args = (A'', A', A)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> (x'' * x' * x)[1, 1]
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> (x''' * x'' * x' * x)[1, 1]
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> (x''' * x'' * x' * x)[1, 1]
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = (x, y) -> (x + y)[1, 1]
+  args = (A, B)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> (x + x)[1, 1]
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> (2x)[1, 1]
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> (x + 2x)[1, 1]
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> (x + 2 * mapprime(x' * x, 2 => 1))[1, 1]
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = (x, y) -> (x * y)[]
+  args = (A, δ(dag(inds(A))))
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> (x * x)[]
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> (x * δ(dag(inds(x))))[]
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = function (x)
+    y = x' * x
+    tr = δ(dag(inds(y)))
+    return (y * tr)[]
+  end
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = function (x)
+    y = x'' * x' * x
+    tr = δ(dag(inds(y)))
+    return (y * tr)[]
+  end
+  args = (A,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> (x^2 * δ((i', i)))[1, 1]
+  args = (2.2,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> (x^2 * δ(i', i))[1, 1]
+  args = (2.2,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> itensor([x^2 x; x^3 x^4], i', i)
+  args = (2.3,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> ITensor([x^2 x; x^3 x^4], i', i)
+  args = (2.3,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> ITensor(x)
+  args = (2.3,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
 end

--- a/test/ITensorChainRules/runtests.jl
+++ b/test/ITensorChainRules/runtests.jl
@@ -58,7 +58,9 @@ function FiniteDifferences.rand_tangent(rng::AbstractRNG, x::Tuple{Vararg{Index}
   return NoTangent()
 end
 
-function FiniteDifferences.rand_tangent(rng::AbstractRNG, x::Pair{<:Tuple{Vararg{Index}},<:Tuple{Vararg{Index}}})
+function FiniteDifferences.rand_tangent(
+  rng::AbstractRNG, x::Pair{<:Tuple{Vararg{Index}},<:Tuple{Vararg{Index}}}
+)
   return NoTangent()
 end
 
@@ -103,7 +105,9 @@ end
   test_rrule(addtags, A, "x"; check_inferred=false)
   test_rrule(removetags, A, "i"; check_inferred=false)
   test_rrule(replacetags, A, "i" => "j"; check_inferred=false)
-  test_rrule(swaptags, randomITensor(Index(2, "i"), Index(2, "j")), "i" => "j"; check_inferred=false)
+  test_rrule(
+    swaptags, randomITensor(Index(2, "i"), Index(2, "j")), "i" => "j"; check_inferred=false
+  )
   test_rrule(replaceind, A, i' => sim(i); check_inferred=false)
   test_rrule(replaceinds, A, (i, i') => (sim(i), sim(i)); check_inferred=false)
   test_rrule(swapind, A, i', i; check_inferred=false)

--- a/test/ITensorChainRules/runtests.jl
+++ b/test/ITensorChainRules/runtests.jl
@@ -98,103 +98,120 @@ end
 
   f = x -> sin(scalar(x)^3)
   args = (C,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> sin(x[]^3)
   args = (C,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = adjoint
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = (x, y) -> (x * y)[1, 1]
   args = (A', A)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> prime(x, 2)[1, 1]
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> x'[1, 1]
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> addtags(x, "x")[1, 1]
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> (x' * x)[1, 1]
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> (prime(x) * x)[1, 1]
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> ((x'' * x') * x)[1, 1]
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> (x'' * (x' * x))[1, 1]
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = (x, y, z) -> (x * y * z)[1, 1]
   args = (A'', A', A)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> (x'' * x' * x)[1, 1]
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> (x''' * x'' * x' * x)[1, 1]
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> (x''' * x'' * x' * x)[1, 1]
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = (x, y) -> (x + y)[1, 1]
   args = (A, B)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> (x + x)[1, 1]
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> (2x)[1, 1]
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> (x + 2x)[1, 1]
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> (x + 2 * mapprime(x' * x, 2 => 1))[1, 1]
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = (x, y) -> (x * y)[]
   args = (A, δ(dag(inds(A))))
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> (x * x)[]
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> (x * δ(dag(inds(x))))[]
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = function (x)
     y = x' * x
     tr = δ(dag(inds(y)))
     return (y * tr)[]
   end
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = function (x)
     y = x'' * x' * x
     tr = δ(dag(inds(y)))
     return (y * tr)[]
   end
   args = (A,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> (x^2 * δ((i', i)))[1, 1]
   args = (6.2,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> (x^2 * δ(i', i))[1, 1]
   args = (5.2,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> itensor([x^2 x; x^3 x^4], i', i)
   args = (2.54,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> ITensor([x^2 x; x^3 x^4], i', i)
   args = (2.1,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> ITensor(x)
   args = (2.12,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
-  f = x -> (j = Index(2); T = itensor([x^2 sin(x); x^2 exp(-2x)], j', dag(j)); (dag(T) * T)[])
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
+  f =
+    x -> (
+      j = Index(2); T = itensor([x^2 sin(x); x^2 exp(-2x)], j', dag(j)); real(
+        (dag(T) * T)[]
+      )
+    )
   args = (2.8,)
-  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
+  args = (2.8 + 3.1im,)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
+  f = function f(x)
+    j = Index(2)
+    v = itensor([exp(-3.2x), cos(2x^2)], j)
+    T = itensor([x^2 sin(x); x^2 exp(-2x)], j', dag(j))
+    return real((dag(v') * T * v)[])
+  end
+  args = (2.8,)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
+  args = (2.8 + 3.1im,)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
 end

--- a/test/ITensorChainRules/runtests.jl
+++ b/test/ITensorChainRules/runtests.jl
@@ -32,6 +32,11 @@ function FiniteDifferences.to_vec(A::ITensor)
   end
   return vec(array(A)), vec_to_ITensor
 end
+
+function FiniteDifferences.to_vec(x::Index)
+  return (Bool[], _ -> x)
+end
+
 function FiniteDifferences.rand_tangent(rng::AbstractRNG, A::ITensor)
   # TODO: generalize to sparse tensors
   return isempty(inds(A)) ? ITensor(randn(eltype(A))) : randomITensor(eltype(A), inds(A))
@@ -89,6 +94,7 @@ end
   test_rrule(itensor, randn(2, 2), i', i; check_inferred=false)
   test_rrule(ITensor, randn(2, 2), i', i; check_inferred=false)
   test_rrule(ITensor, 2.3; check_inferred=false)
+  test_rrule(dag, A; check_inferred=false)
 
   f = x -> sin(scalar(x)^3)
   args = (C,)
@@ -174,18 +180,21 @@ end
   args = (A,)
   test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> (x^2 * δ((i', i)))[1, 1]
-  args = (2.2,)
+  args = (6.2,)
   test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> (x^2 * δ(i', i))[1, 1]
-  args = (2.2,)
+  args = (5.2,)
   test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> itensor([x^2 x; x^3 x^4], i', i)
-  args = (2.3,)
+  args = (2.54,)
   test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> ITensor([x^2 x; x^3 x^4], i', i)
-  args = (2.3,)
+  args = (2.1,)
   test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
   f = x -> ITensor(x)
-  args = (2.3,)
+  args = (2.12,)
+  test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
+  f = x -> (j = Index(2); T = itensor([x^2 sin(x); x^2 exp(-2x)], j', dag(j)); (dag(T) * T)[])
+  args = (2.8,)
   test_rrule(ZygoteRuleConfig(), f, args..., rrule_f=rrule_via_ad, check_inferred=false)
 end

--- a/test/ITensorChainRules/runtests.jl
+++ b/test/ITensorChainRules/runtests.jl
@@ -14,11 +14,6 @@ using Zygote: ZygoteRuleConfig
 # ITensor extensions
 #
 
-# TODO: this is to fix an error within `ChainRulesTestUtils._test_add!!_behaviour`
-# that gets called in `test_rrule`. Is this needed/a good definition?
-Base.:+(x::Number, y::ITensor) = ITensor(x) + y
-Base.:+(x::ITensor, y::Number) = x + ITensor(y)
-
 #
 # For ITensor compatibility with FiniteDifferences
 #
@@ -212,5 +207,11 @@ end
   args = (2.8,)
   test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
   args = (2.8 + 3.1im,)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
+  f = function (x)
+    j = Index(2)
+    return real((x^3 * ITensor([sin(x) exp(-2x); 3x^3 x+x^2], j', dag(j)))[1, 1])
+  end
+  args = (3.4 + 2.3im,)
   test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"


### PR DESCRIPTION
This adds more `ChainRules` `rrule` definitions in order to cover a wider range of ITensor operations.

It includes priming and tagging functions like `prime`, `addtags`, etc., `getindex`, contraction, addition, construction from `Array` and `Number`, and `dag`.

@LinjianMa I think this should cover the rules you need for the ITensor-AutoHOOT interface.