### PR TITLE
Adding projections based on the BMPS algorithm

### DIFF
--- a/examples/Optimizations/approximate_peps.jl
+++ b/examples/Optimizations/approximate_peps.jl
@@ -11,16 +11,7 @@ using ITensorNetworkAD.Optimizations: gd_error_tracker
   peps = PEPS(sites; linkdims=2)
   randn!(peps)
   H_line = Models.lineham(Models.Model("tfim"), sites; h=1.0)
-  H_row = [H for H in H_line if H.coord[2] isa Colon]
-  H_column = [H for H in H_line if H.coord[1] isa Colon]
-
   gd_error_tracker(
-    peps,
-    H_row,
-    H_column;
-    stepsize=0.005,
-    num_sweeps=num_sweeps,
-    cutoff=cutoff,
-    maxdim=maxdim,
+    peps, H_line; stepsize=0.005, num_sweeps=num_sweeps, cutoff=cutoff, maxdim=maxdim
   )
 end

--- a/examples/Optimizations/approximate_peps.jl
+++ b/examples/Optimizations/approximate_peps.jl
@@ -5,10 +5,22 @@ using ITensorNetworkAD.Optimizations: gd_error_tracker
 @testset "test error of approximate peps" begin
   Nx, Ny = 3, 3
   num_sweeps = 20
-  maxdim = 1
+  cutoff = 1e-15
+  maxdim = 100
   sites = siteinds("S=1/2", Ny, Nx)
   peps = PEPS(sites; linkdims=2)
   randn!(peps)
-  H_local = Models.localham(Models.Model("tfim"), sites; h=1.0)
-  gd_error_tracker(peps, H_local; stepsize=0.005, num_sweeps=num_sweeps, maxdim=maxdim)
+  H_line = Models.lineham(Models.Model("tfim"), sites; h=1.0)
+  H_row = [H for H in H_line if H.coord[2] isa Colon]
+  H_column = [H for H in H_line if H.coord[1] isa Colon]
+
+  gd_error_tracker(
+    peps,
+    H_row,
+    H_column;
+    stepsize=0.005,
+    num_sweeps=num_sweeps,
+    cutoff=cutoff,
+    maxdim=maxdim,
+  )
 end

--- a/src/ITensorNetworks/boundary_mps.jl
+++ b/src/ITensorNetworks/boundary_mps.jl
@@ -142,7 +142,10 @@ default_projector_center(tn::Matrix) = (:, (size(tn, 2) + 1) ÷ 2)
 
 # Split the links of the 2D tensor network in preperation for
 # inserting MPS projectors.
-function split_network(tn::Matrix{ITensor}; projector_center=default_projector_center(tn))
+function split_network(
+  tn::Matrix{ITensor}; projector_center=default_projector_center(tn), rotation=false
+)
+  tn = rotation ? rotr90(tn) : tn
   @assert (projector_center[1] == :)
   tn_split = copy(tn)
   nrows, ncols = size(tn)
@@ -154,7 +157,7 @@ function split_network(tn::Matrix{ITensor}; projector_center=default_projector_c
       tn_split[:, ncol] = split_links(tn_split[:, ncol])
     end
   end
-  return tn_split
+  return rotation ? rotr90(tn_split, -1) : tn_split
 end
 
 # From an MPS, create a 1-site projector onto the MPS basis

--- a/src/ITensorNetworks/chain_rules.jl
+++ b/src/ITensorNetworks/chain_rules.jl
@@ -79,12 +79,18 @@ function ChainRulesCore.rrule(::typeof(flatten), v::Array{<:PEPS})
   return flatten(v), adjoint_pullback
 end
 
+@non_differentiable inner_network(peps::PEPS, peps_prime::PEPS)
+
+@non_differentiable inner_network(
+  peps::PEPS, peps_prime::PEPS, projectors::Vector{<:ITensor}
+)
+
 # gradient of this function returns nothing.
-@non_differentiable generate_inner_network(
+@non_differentiable inner_networks(
   peps::PEPS, peps_prime::PEPS, peps_prime_ham::PEPS, Hs::Array
 )
 
-@non_differentiable generate_inner_network(
+@non_differentiable inner_networks(
   peps::PEPS,
   peps_prime::PEPS,
   peps_prime_ham::PEPS,
@@ -92,7 +98,7 @@ end
   Hs::Array,
 )
 
-@non_differentiable generate_inner_network(
+@non_differentiable inner_networks(
   peps::PEPS,
   peps_prime::PEPS,
   peps_prime_ham::PEPS,

--- a/src/ITensorNetworks/chain_rules.jl
+++ b/src/ITensorNetworks/chain_rules.jl
@@ -6,12 +6,13 @@ function ChainRulesCore.rrule(
   ::typeof(split_network),
   tn::Matrix{ITensor};
   projector_center=default_projector_center(tn),
+  rotation=false,
 )
   function pullback(dtn_split::Matrix{ITensor})
     dtn = map(t -> replaceprime(t, 1 => 0), dtn_split)
-    return (NoTangent(), dtn, NoTangent())
+    return (NoTangent(), dtn, NoTangent(), NoTangent())
   end
-  return split_network(tn; projector_center=projector_center), pullback
+  return split_network(tn; projector_center=projector_center, rotation=rotation), pullback
 end
 
 function ChainRulesCore.rrule(::typeof(ITensors.data), P::PEPS)
@@ -87,11 +88,21 @@ end
   peps::PEPS,
   peps_prime::PEPS,
   peps_prime_ham::PEPS,
-  projectors::Array{<:ITensor,1},
+  projectors::Vector{<:ITensor},
   Hs::Array,
 )
 
-@non_differentiable insert_projectors(peps::PEPS, center, cutoff, maxdim)
+@non_differentiable generate_inner_network(
+  peps::PEPS,
+  peps_prime::PEPS,
+  peps_prime_ham::PEPS,
+  projectors::Vector{Vector{ITensor}},
+  Hs::Vector{Tuple},
+)
+
+@non_differentiable insert_projectors(peps::PEPS, cutoff, maxdim)
+
+@non_differentiable insert_projectors(peps::PEPS, center::Tuple, cutoff, maxdim)
 
 @non_differentiable ITensors.commoninds(p1::PEPS, p2::PEPS)
 

--- a/src/ITensorNetworks/chain_rules.jl
+++ b/src/ITensorNetworks/chain_rules.jl
@@ -10,7 +10,7 @@ function ChainRulesCore.rrule(
 )
   function pullback(dtn_split::Matrix{ITensor})
     dtn = map(t -> replaceprime(t, 1 => 0), dtn_split)
-    return (NoTangent(), dtn, NoTangent(), NoTangent())
+    return (NoTangent(), dtn)
   end
   return split_network(tn; projector_center=projector_center, rotation=rotation), pullback
 end
@@ -81,9 +81,7 @@ end
 
 @non_differentiable inner_network(peps::PEPS, peps_prime::PEPS)
 
-@non_differentiable inner_network(
-  peps::PEPS, peps_prime::PEPS, projectors::Vector{<:ITensor}
-)
+@non_differentiable inner_network(peps::PEPS, peps_prime::PEPS, projectors::Vector{ITensor})
 
 # gradient of this function returns nothing.
 @non_differentiable inner_networks(
@@ -91,11 +89,7 @@ end
 )
 
 @non_differentiable inner_networks(
-  peps::PEPS,
-  peps_prime::PEPS,
-  peps_prime_ham::PEPS,
-  projectors::Vector{<:ITensor},
-  Hs::Array,
+  peps::PEPS, peps_prime::PEPS, peps_prime_ham::PEPS, projectors::Vector{ITensor}, Hs::Array
 )
 
 @non_differentiable inner_networks(

--- a/src/ITensorNetworks/peps.jl
+++ b/src/ITensorNetworks/peps.jl
@@ -117,7 +117,7 @@ function inner_network(peps::PEPS, peps_prime::PEPS)
   return vcat(vcat(peps.data...), vcat(peps_prime.data...))
 end
 
-function inner_network(peps::PEPS, peps_prime::PEPS, projectors::Vector{<:ITensor})
+function inner_network(peps::PEPS, peps_prime::PEPS, projectors::Vector{ITensor})
   network = inner_network(peps::PEPS, peps_prime::PEPS)
   return vcat(network, projectors)
 end
@@ -219,11 +219,7 @@ function inner_networks(peps::PEPS, peps_prime::PEPS, peps_prime_ham::PEPS, Hs::
 end
 
 function inner_networks(
-  peps::PEPS,
-  peps_prime::PEPS,
-  peps_prime_ham::PEPS,
-  projectors::Vector{<:ITensor},
-  Hs::Array,
+  peps::PEPS, peps_prime::PEPS, peps_prime_ham::PEPS, projectors::Vector{ITensor}, Hs::Array
 )
   network_list = inner_networks(peps, peps_prime, peps_prime_ham, Hs)
   return map(network -> vcat(network, projectors), network_list)

--- a/test/ITensorNetworks/peps.jl
+++ b/test/ITensorNetworks/peps.jl
@@ -1,7 +1,16 @@
 using ITensors, ITensorNetworkAD, AutoHOOT
 using ITensorNetworkAD.ITensorNetworks:
-  PEPS, inner_network, broadcast_add, broadcast_minus, broadcast_mul, broadcast_inner
-using ITensorNetworkAD.ITensorAutoHOOT: generate_optimal_tree
+  PEPS,
+  Models,
+  inner_network,
+  broadcast_add,
+  broadcast_minus,
+  broadcast_mul,
+  broadcast_inner,
+  insert_projectors,
+  split_network,
+  generate_inner_network
+using ITensorNetworkAD.ITensorAutoHOOT: generate_optimal_tree, batch_tensor_contraction
 
 @testset "test peps" begin
   Nx = 4
@@ -74,5 +83,66 @@ end
       @test isapprox(peps3.data[j, i], peps1.data[j, i] + peps2.data[j, i])
       @test isapprox(peps4.data[j, i], peps1.data[j, i] - peps2.data[j, i])
     end
+  end
+end
+
+@testset "test insert projectors" begin
+  Nx, Ny = 3, 3
+  sites = siteinds("S=1/2", Ny, Nx)
+  peps = PEPS(sites; linkdims=2)
+  randn!(peps)
+  tn_split_row, tn_split_column, projectors_row, projectors_column = insert_projectors(peps)
+  for i in 2:length(tn_split_row)
+    for (t1, t2) in zip(tn_split_row[1], tn_split_row[i])
+      @test t1 == t2
+    end
+  end
+  for i in 2:length(tn_split_column)
+    for (t1, t2) in zip(tn_split_column[1], tn_split_column[i])
+      @test t1 == t2
+    end
+  end
+end
+
+@testset "test split network with hamiltonian" begin
+  Nx, Ny = 3, 3
+  sites = siteinds("S=1/2", Ny, Nx)
+  peps = PEPS(sites; linkdims=2)
+  randn!(peps)
+
+  H_line = Models.lineham(Models.Model("tfim"), sites; h=1.0)
+  H_row = [H for H in H_line if H.coord[2] isa Colon]
+  H_column = [H for H in H_line if H.coord[1] isa Colon]
+
+  _, _, projectors_row, projectors_column = insert_projectors(peps)
+  peps_bra = addtags(linkinds, peps, "bra")
+  peps_ket = addtags(linkinds, peps, "ket")
+  peps_bra_rot = addtags(linkinds, peps, "brarot")
+  peps_ket_rot = addtags(linkinds, peps, "ketrot")
+  sites = commoninds(peps_bra, peps_ket)
+  peps_bra_split = split_network(peps_bra)
+  peps_ket_split = split_network(peps_ket)
+  peps_ket_split_ham = prime(sites, peps_ket_split)
+  peps_bra_split_rot = split_network(peps_bra_rot, true)
+  peps_ket_split_rot = split_network(peps_ket_rot, true)
+  peps_ket_split_rot_ham = prime(sites, peps_ket_split_rot)
+
+  for i in 1:length(projectors_row)
+    network_list = generate_inner_network(
+      peps_bra_split, peps_ket_split, peps_ket_split_ham, projectors_row[i], [H_row[i]]
+    )
+    inners = batch_tensor_contraction(network_list)
+    @test size(inners[1]) == ()
+  end
+  for i in 1:length(projectors_column)
+    network_list = generate_inner_network(
+      peps_bra_split_rot,
+      peps_ket_split_rot,
+      peps_ket_split_rot_ham,
+      projectors_column[i],
+      [H_column[i]],
+    )
+    inners = batch_tensor_contraction(network_list)
+    @test size(inners[1]) == ()
   end
 end

--- a/test/ITensorNetworks/peps.jl
+++ b/test/ITensorNetworks/peps.jl
@@ -9,7 +9,7 @@ using ITensorNetworkAD.ITensorNetworks:
   broadcast_inner,
   insert_projectors,
   split_network,
-  generate_inner_network
+  inner_networks
 using ITensorNetworkAD.ITensorAutoHOOT: generate_optimal_tree, batch_tensor_contraction
 
 @testset "test peps" begin
@@ -128,14 +128,14 @@ end
   peps_ket_split_rot_ham = prime(sites, peps_ket_split_rot)
 
   for i in 1:length(projectors_row)
-    network_list = generate_inner_network(
+    network_list = inner_networks(
       peps_bra_split, peps_ket_split, peps_ket_split_ham, projectors_row[i], [H_row[i]]
     )
     inners = batch_tensor_contraction(network_list)
     @test size(inners[1]) == ()
   end
   for i in 1:length(projectors_column)
-    network_list = generate_inner_network(
+    network_list = inner_networks(
       peps_bra_split_rot,
       peps_ket_split_rot,
       peps_ket_split_rot_ham,

--- a/test/Optimizations/runtests.jl
+++ b/test/Optimizations/runtests.jl
@@ -1,12 +1,6 @@
 using ITensors, ITensorNetworkAD, AutoHOOT, Zygote, OptimKit
 using ITensorNetworkAD.ITensorNetworks:
-  PEPS,
-  inner_network,
-  Models,
-  flatten,
-  insert_projectors,
-  split_network,
-  generate_inner_network
+  PEPS, inner_network, Models, flatten, insert_projectors, split_network
 using ITensorNetworkAD.Optimizations: gradient_descent
 using ITensorNetworkAD.ITensorAutoHOOT: batch_tensor_contraction
 
@@ -137,7 +131,7 @@ end
   function loss(peps::PEPS)
     peps_prime = prime(linkinds, peps)
     peps_prime_ham = prime(peps)
-    network_list = generate_inner_network(peps, peps_prime, peps_prime_ham, [])
+    network_list = [inner_network(peps, peps_prime)]
     variables = flatten([peps, peps_prime])
     inners = batch_tensor_contraction(network_list, variables...)
     return sum(inners)[]
@@ -161,9 +155,7 @@ end
     peps_ket = addtags(linkinds, peps, "ket")
     peps_bra_split = split_network(peps_bra)
     peps_ket_split = split_network(peps_ket)
-    network_list = generate_inner_network(
-      peps_bra_split, peps_ket_split, peps_ket_split, projectors, []
-    )
+    network_list = [inner_network(peps_bra_split, peps_ket_split, projectors)]
     variables = flatten([peps_bra_split, peps_ket_split])
     inners = batch_tensor_contraction(network_list, variables...)
     return sum(inners)[]
@@ -184,9 +176,8 @@ end
     peps_bra = addtags(linkinds, peps, "bra")
     peps_ket = addtags(linkinds, peps, "ket")
     sites = commoninds(peps_bra, peps_ket)
-    peps_ket_ham = prime(sites, peps_ket)
     projectors = [ITensor(1.0)]
-    network_list = generate_inner_network(peps_bra, peps_ket, peps_ket_ham, projectors, [])
+    network_list = [inner_network(peps_bra, peps_ket, projectors)]
     variables = flatten([peps_bra, peps_ket])
     inners = batch_tensor_contraction(network_list, variables...)
     return sum(inners)[]

--- a/test/Optimizations/runtests.jl
+++ b/test/Optimizations/runtests.jl
@@ -48,13 +48,9 @@ end
   peps = PEPS(sites; linkdims=2)
   randn!(peps)
   H_line = Models.lineham(Models.Model("tfim"), sites; h=1.0)
-  H_row = [H for H in H_line if H.coord[2] isa Colon]
-  H_column = [H for H in H_line if H.coord[1] isa Colon]
-
   losses_gd = gradient_descent(
     peps,
-    H_row,
-    H_column,
+    H_line,
     insert_projectors;
     stepsize=0.005,
     num_sweeps=num_sweeps,


### PR DESCRIPTION
Previously we use the same set of projectors for all the inner products <psi|H|psi>. This PR changes it such that for each H representing a row or column, the projectors inserted are chosen based on the BMPS.