### PR TITLE
Add back tracking line search for gradient descent

### DIFF
--- a/test/Optimizations/runtests.jl
+++ b/test/Optimizations/runtests.jl
@@ -61,10 +61,10 @@ end
     cutoff=cutoff,
     maxdim=maxdim,
   )
-  for i in 3:(length(losses_gd) - 1)
+  for i in 3:(length(losses_gdls) - 1)
     @test losses_gdls[i] >= losses_gdls[i + 1]
   end
-  @test abs(energy - losses_gd[end]) < 0.5
+  @test abs(energy - losses_gdls[end]) < 0.5
 end
 
 @testset "test the equivalence of local and line hamiltonian" begin


### PR DESCRIPTION
This PR is on top of #33 #34 

Added a basic backtracking line search function to accelerate gradient descent.

For now, the major problem for large system PEPS optimization is that the optimization will easily get stuck at local minima that is far from the point DMRG can get. These phenomena appear on all the methods I tested (gradient descent, LBFGS, CG, both with and without line search).

We can think of is there ways for us to initialize PEPS based on DMRG results, such that the gradient optimization can be at least as good as some DMRG results, and second order methods make more sense for this case.